### PR TITLE
For StatusSchema attribute 'date_floating' set optional. for compatible with Wordpress 5.x

### DIFF
--- a/.changeset/dry-spiders-enjoy.md
+++ b/.changeset/dry-spiders-enjoy.md
@@ -1,0 +1,5 @@
+---
+"dewp": patch
+---
+
+Fixes `StatusSchema` for better Wordpress 5.x compatibility

--- a/packages/dewp/schemas.ts
+++ b/packages/dewp/schemas.ts
@@ -275,6 +275,7 @@ export const StatusSchema = z.object({
 	slug: z.string().describe('An alphanumeric identifier for the status.'),
 	date_floating: z
 		.boolean()
+		.optional()
 		.describe('Whether posts of this status may have floating published dates.'),
 });
 


### PR DESCRIPTION
## Problem
If website use old Wordpress 5.x. then throw error.
```
$ npm run build
10:59:20 [content] Syncing content
[InvalidContentEntryDataError] statuses → publish data does not match collection schema.
date_floating: Required
  Hint:
    See https://docs.astro.build/en/guides/content-collections/ for more information on content schemas.
  Error reference:
    https://docs.astro.build/en/reference/errors/invalid-content-entry-data-error/
  Location:
    /home/developer/wp_astro/node_modules/astro/dist/core/errors/errors.js:13:5
  Stack trace:
    at new AstroError (/home/developer/wp_astro/node_modules/astro/dist/core/errors/errors.js:13:5)
    at processTicksAndRejections (native:7:39)
error: script "build" exited with code 1
```

## Resolve
For StatusSchema attribute 'date_floating' set optional.
